### PR TITLE
Update docs on running validator + helper scripts for generating keys

### DIFF
--- a/docs/liberland/how_to_run_validator.md
+++ b/docs/liberland/how_to_run_validator.md
@@ -25,7 +25,7 @@ get a legitimate copy of the binary.
 
 ```shell
 $ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-$ cargo install --force subkey --git https://github.com/paritytech/substrate --version 2.0.1 --locked
+$ cargo install --force subkey --git https://github.com/paritytech/substrate --version 2.0.2 --locked
 ```
 
 
@@ -73,8 +73,8 @@ Example:
 #### Automatically:
 You can automatically generate and insert new session keys into your node using:
 ```shell
-$ sh scripts/generate_stored_keys.sh
-$ sh scripts/insert_keys_gen.sh
+$ bash scripts/generate_stored_keys.sh
+$ bash scripts/ig.sh
 ```
 
 
@@ -90,6 +90,16 @@ Babe key:
 $ subkey generate --scheme sr25519
 ```
 
+im_online key:
+```shell 
+$ subkey generate --scheme sr25519
+```
+
+Authority discovery key:
+```shell 
+$ subkey generate --scheme sr25519
+```
+
 Save the output from subkey in a safe place.
 
 Upload these hot keys to our node:
@@ -97,6 +107,10 @@ Upload these hot keys to our node:
 curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "author_insertKey", "params":["babe", "mnemonic phrase here from Grandpa", "publickeygoesherefrom Grandpa"] }' http://127.0.0.1:9933
 
 curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "author_insertKey", "params":["gran", "mnemonic phrase here from babe", "publickeygoeshere from grandpa"] }' http://127.0.0.1:9933
+
+curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "author_insertKey", "params":["imol", "mnemonic phrase here from im_online", "publickeygoeshere from imol"] }' http://127.0.0.1:9933
+
+curl -H "Content-Type: application/json" -d '{"id":1, "jsonrpc":"2.0", "method": "author_insertKey", "params":["audi", "mnemonic phrase here from authority discovery", "publickeygoeshere from authority discovery"] }' http://127.0.0.1:9933
 
 ```
 

--- a/scripts/generate_stored_keys.sh
+++ b/scripts/generate_stored_keys.sh
@@ -40,7 +40,7 @@ generate_address_and_account_id() {
 	printf "SD:	 s/$M/${SECRET:2}/g \n"
 	printf "AC:	 s/$ACCOUNT_PREFIX/0x$PUBLIC_KEY/g \n"
 	sed -i "s/$M/${SECRET:2}/g" ig.sh
-	sed -i "s/$ACCOUNT_PREFIX/$ADDRESS/g" ig.sh
+	sed -i "s/$ACCOUNT_PREFIX/${PUBLIC_KEY#'0x'}/g" ig.sh
 	printf "Key Type	: $1\n"
 	printf "Address		: ${ADDRESS}\n"
 	printf "A Prefix		: ${ACCOUNT_PREFIX}\n"

--- a/scripts/insert_keys_gen.sh
+++ b/scripts/insert_keys_gen.sh
@@ -36,7 +36,7 @@ curl http://localhost:9933  -H "Content-Type:application/json;charset=utf-8" -d 
     "id":1,
     "method":"author_insertKey",
     "params": [
-        "authority_discovery",
+        "audi",
         "MNEMONIC_authority_discovery//authority_discovery",
         "ACCOUNT_authority_discovery"
     ]


### PR DESCRIPTION
Updates to `how_to_run_validator.md`:
1. Bump `subkey` version
2. Ask user to run `ig.sh` and use `bash` instead of `sh`
3. add `imol` and `audi` keys
4. Use pubkey instead of address when injecting keys to node in `ig.sh`