### PR TITLE
Use T::Balance instead of u64/u128 for LLM amounts

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1297,7 +1297,7 @@ parameter_types! {
 
 impl pallet_assets::Config for Runtime {
 	type Event = Event;
-	type Balance = u128;
+	type Balance = Balance;
 	type AssetId = u32;
 	type Currency = Balances;
 	type ForceOrigin = EnsureRoot<AccountId>;
@@ -1324,8 +1324,8 @@ parameter_types! {
 }
 
 parameter_types! {
-	pub const TOTALLLM: u64 = 70000000u64;
-	pub const PREMINTLLM: u64 = 7000000u64;
+	pub const TOTALLLM: Balance = 70000000u128;
+	pub const PREMINTLLM: Balance = 7000000u128;
 	pub const ASSETID: u32 = 0u32; // asset id 0 for llm
 }
 

--- a/frame/llm/src/traits.rs
+++ b/frame/llm/src/traits.rs
@@ -7,7 +7,7 @@ pub trait LLM<AccountId, Balance> {
 	/// check if sender has election rights unlocked
 	fn is_election_unlocked(account: &AccountId) -> bool;
 	/// get amount of politipooled LLM
-	fn get_politi_pooled_amount() -> u64;
+	fn get_politi_pooled_amount() -> Balance;
 	/// get amount of free LLM for politics for account
 	fn get_llm_politics(account: &AccountId) -> Balance;
 }


### PR DESCRIPTION
See title.

We should also replace things like `try_into().unwrap_or(0));` with actual error handling, but that's for another time.

This PR is part of #132.