### PR TITLE
Fix tests for node-inspect

### DIFF
--- a/bin/node/inspect/src/lib.rs
+++ b/bin/node/inspect/src/lib.rs
@@ -296,7 +296,7 @@ mod tests {
 		let b2 = ExtrinsicAddress::from_str("0 0");
 		let b3 = ExtrinsicAddress::from_str("0x0012345f");
 
-		assert_eq!(e0, Err("Extrinsic index missing: example \"5:0\"".into()));
+		assert_eq!(e0, Ok(ExtrinsicAddress::Bytes(vec![0x12, 0x34])));
 		assert_eq!(
 			b0,
 			Ok(ExtrinsicAddress::Block(
@@ -305,7 +305,7 @@ mod tests {
 			))
 		);
 		assert_eq!(b1, Ok(ExtrinsicAddress::Block(BlockAddress::Number(1234), 0)));
-		assert_eq!(b2, Ok(ExtrinsicAddress::Block(BlockAddress::Number(0), 0)));
+		assert_eq!(b2, Ok(ExtrinsicAddress::Bytes(vec![0, 0])));
 		assert_eq!(b3, Ok(ExtrinsicAddress::Bytes(vec![0, 0x12, 0x34, 0x5f])));
 	}
 }


### PR DESCRIPTION
This backports changes from https://github.com/paritytech/substrate/commit/fc67cbb66d8c484bc7b7506fc1300344d12ecbad#diff-a144cf4e64315c8eef985e013fa81335f0bac27c0e0f0a9eaf3188e747062f8f , so I guess there's no need to update copyright notices.

Part of #156 