### PR TITLE
Fix tests for node-cli

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -142,7 +142,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 
 	let endowed_accounts: Vec<AccountId> = vec![root_key.clone()];
 
-	testnet_genesis(initial_authorities, vec![], root_key, Some(endowed_accounts))
+	testnet_genesis(initial_authorities, vec![], root_key, Some(endowed_accounts), Some(vec![]))
 }
 
 fn properties() -> sc_chain_spec::Properties {
@@ -219,6 +219,7 @@ pub fn testnet_genesis(
 	initial_nominators: Vec<AccountId>,
 	root_key: AccountId,
 	endowed_accounts: Option<Vec<AccountId>>,
+	council_group: Option<Vec<AccountId>>,
 ) -> GenesisConfig {
 	let mut endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
 		vec![
@@ -237,11 +238,11 @@ pub fn testnet_genesis(
 		]
 	});
 
-	let council_group: Vec<AccountId> = vec![
+	let council_group: Vec<AccountId> = council_group.unwrap_or(vec![
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		get_account_id_from_seed::<sr25519::Public>("Bob"),
 		get_account_id_from_seed::<sr25519::Public>("Charlie"),
-	];
+	]);
 
 	// endow all authorities and nominators.
 	initial_authorities
@@ -368,6 +369,7 @@ fn development_config_genesis() -> GenesisConfig {
 		vec![],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		None,
+		None,
 	)
 }
 
@@ -392,6 +394,7 @@ fn local_testnet_genesis() -> GenesisConfig {
 		vec![authority_keys_from_seed("Alice"), authority_keys_from_seed("Bob")],
 		vec![],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		None,
 		None,
 	)
 }
@@ -424,6 +427,7 @@ pub(crate) mod tests {
 			vec![authority_keys_from_seed("Alice")],
 			vec![],
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
+			None,
 			None,
 		)
 	}

--- a/bin/node/cli/tests/running_the_node_and_interrupt.rs
+++ b/bin/node/cli/tests/running_the_node_and_interrupt.rs
@@ -45,7 +45,7 @@ async fn running_the_node_works_and_can_be_interrupted() {
 				.unwrap(),
 		);
 
-		common::wait_n_finalized_blocks(3, 30).await.unwrap();
+		common::wait_n_finalized_blocks(3, 60).await.unwrap();
 		assert!(cmd.try_wait().unwrap().is_none(), "the process should still be running");
 		kill(Pid::from_raw(cmd.id().try_into().unwrap()), signal).unwrap();
 		assert_eq!(

--- a/bin/node/cli/tests/temp_base_path_works.rs
+++ b/bin/node/cli/tests/temp_base_path_works.rs
@@ -45,7 +45,7 @@ async fn temp_base_path_works() {
 	);
 
 	// Let it produce some blocks.
-	common::wait_n_finalized_blocks(3, 30).await.unwrap();
+	common::wait_n_finalized_blocks(3, 60).await.unwrap();
 	assert!(child.try_wait().unwrap().is_none(), "the process should still be running");
 
 	// Stop the process

--- a/bin/utils/chain-spec-builder/src/main.rs
+++ b/bin/utils/chain-spec-builder/src/main.rs
@@ -113,6 +113,7 @@ fn genesis_constructor(
 		nominator_accounts.to_vec(),
 		sudo_account.clone(),
 		Some(endowed_accounts.to_vec()),
+		Some(vec![]),
 	)
 }
 


### PR DESCRIPTION
Part of #156 
Also a fix for #154 and #106 , now `--chain staging` will work without needing to export chain spec and remove members.