### PR TITLE
Fix tests for node-cli

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -145,7 +145,7 @@ fn staging_testnet_config_genesis() -> GenesisConfig {
 
 	let endowed_accounts: Vec<AccountId> = vec![root_key.clone()];
 
-	testnet_genesis(initial_authorities, vec![], root_key, Some(endowed_accounts))
+	testnet_genesis(initial_authorities, vec![], root_key, Some(endowed_accounts), Some(vec![]))
 }
 
 fn properties() -> sc_chain_spec::Properties {
@@ -222,6 +222,7 @@ pub fn testnet_genesis(
 	initial_nominators: Vec<AccountId>,
 	root_key: AccountId,
 	endowed_accounts: Option<Vec<AccountId>>,
+	council_group: Option<Vec<AccountId>>,
 ) -> GenesisConfig {
 	let mut endowed_accounts: Vec<AccountId> = endowed_accounts.unwrap_or_else(|| {
 		vec![
@@ -240,11 +241,11 @@ pub fn testnet_genesis(
 		]
 	});
 
-	let council_group: Vec<AccountId> = vec![
+	let council_group: Vec<AccountId> = council_group.unwrap_or(vec![
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		get_account_id_from_seed::<sr25519::Public>("Bob"),
 		get_account_id_from_seed::<sr25519::Public>("Charlie"),
-	];
+	]);
 
 	// endow all authorities and nominators.
 	initial_authorities
@@ -371,6 +372,7 @@ fn development_config_genesis() -> GenesisConfig {
 		vec![],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
 		None,
+		None,
 	)
 }
 
@@ -395,6 +397,7 @@ fn local_testnet_genesis() -> GenesisConfig {
 		vec![authority_keys_from_seed("Alice"), authority_keys_from_seed("Bob")],
 		vec![],
 		get_account_id_from_seed::<sr25519::Public>("Alice"),
+		None,
 		None,
 	)
 }
@@ -427,6 +430,7 @@ pub(crate) mod tests {
 			vec![authority_keys_from_seed("Alice")],
 			vec![],
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
+			None,
 			None,
 		)
 	}

--- a/bin/node/cli/tests/running_the_node_and_interrupt.rs
+++ b/bin/node/cli/tests/running_the_node_and_interrupt.rs
@@ -50,7 +50,7 @@ async fn running_the_node_works_and_can_be_interrupted() {
 
 		let (ws_url, _) = common::find_ws_url_from_output(stderr);
 
-		common::wait_n_finalized_blocks(3, 30, &ws_url)
+		common::wait_n_finalized_blocks(3, 60, &ws_url)
 			.await
 			.expect("Blocks are produced in time");
 		assert!(cmd.try_wait().unwrap().is_none(), "the process should still be running");
@@ -90,7 +90,7 @@ async fn running_two_nodes_with_the_same_ws_port_should_work() {
 	let stderr = first_node.stderr.take().unwrap();
 	let (ws_url, _) = common::find_ws_url_from_output(stderr);
 
-	common::wait_n_finalized_blocks(3, 30, &ws_url).await.unwrap();
+	common::wait_n_finalized_blocks(3, 60, &ws_url).await.unwrap();
 
 	assert!(first_node.try_wait().unwrap().is_none(), "The first node should still be running");
 	assert!(second_node.try_wait().unwrap().is_none(), "The second node should still be running");

--- a/bin/node/cli/tests/temp_base_path_works.rs
+++ b/bin/node/cli/tests/temp_base_path_works.rs
@@ -47,7 +47,7 @@ async fn temp_base_path_works() {
 	let (ws_url, mut data) = common::find_ws_url_from_output(&mut stderr);
 
 	// Let it produce some blocks.
-	common::wait_n_finalized_blocks(3, 30, &ws_url).await.unwrap();
+	common::wait_n_finalized_blocks(3, 60, &ws_url).await.unwrap();
 	assert!(child.try_wait().unwrap().is_none(), "the process should still be running");
 
 	// Stop the process


### PR DESCRIPTION
Part of https://github.com/liberland/liberland_substrate/issues/156

Also a fix for https://github.com/liberland/liberland_substrate/issues/154 and https://github.com/liberland/liberland_substrate/issues/106 , now --chain staging will work without needing to export chain spec and remove members.