### PR TITLE
 Extract withdraw/election lock durations to chain spec

### DIFF
--- a/bin/node/cli/src/chain_spec.rs
+++ b/bin/node/cli/src/chain_spec.rs
@@ -362,6 +362,7 @@ pub fn testnet_genesis(
 		gilt: Default::default(),
 		transaction_storage: Default::default(),
 		transaction_payment: Default::default(),
+		llm: Default::default(),
 	}
 }
 


### PR DESCRIPTION
Currently the duration and withdraw and election locks is linked to the `get_future_block`, which gives a block that's 2 minutes in the future. There are some problems with that:
* we will want the duration to be different between dev/local chains, testnets and mainnet, that's currently not possible
* `get_future_block` is also used for stuff related to minting LLM, we'll definitely want to have it configured separately to locks

This is fixed by moving values to Storage and setting them up via GenesisConfig, which has following advantages:
* we can set it as part of chain spec, so our different nets can have different values
* as durations are now in storage, it'll be easy to later add a possibility to change them via democracy
* adding new chain-specific parameters to LLM pallet will be much easier in the future

This change is backwards-compatible - no storage migrations needed, as we're adding new values with defaults set to 2 minutes.

This PR is part of #132