### PR TITLE
Build & deploy Rust docs to liberland.github.io

### DIFF
--- a/.github/workflows/build_and_deploy_docs.yml
+++ b/.github/workflows/build_and_deploy_docs.yml
@@ -1,0 +1,34 @@
+name: Deploy docs
+on:
+  push:
+    branches:
+      - main
+      - develop
+jobs:
+  build:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.0
+
+      - name: Build docs
+        run: cargo doc --no-deps -p pallet-llm -p pallet-liberland-legislation -p pallet-liberland-initializer
+
+      - name: Deploy to liberland.github.io
+        uses: JamesIves/github-pages-deploy-action@4.1.7
+        with:
+          branch: gh-pages
+          repository-name: liberland/liberland.github.io
+          folder: target/doc/
+          target-folder: rust/${{ github.ref_name }}/
+          clean: true
+          token: ${{ secrets.LIBERLAND_GITHUB_IO_DEPLOY_TOKEN }}

--- a/frame/llm/Cargo.toml
+++ b/frame/llm/Cargo.toml
@@ -43,6 +43,8 @@ std = [
 	"frame-system/std",
 	"log/std",
 	"pallet-balances/std",
+	"pallet-identity/std",
+	"pallet-assets/std",
 	"scale-info/std",
 	"sp-io/std",
 	"sp-runtime/std",


### PR DESCRIPTION
This provides the workflow that builds and deploys, but someone with admin access to repos needs to:
* create an access token that can deploy to liberland.github.io on gh-pages branch
* store the token as secret in liberland_substrate repo under name `LIBERLAND_GITHUB_IO_DEPLOY_TOKEN`

See example pipeline here: https://github.com/liberland/liberland_substrate/actions/runs/3733761688/jobs/6334964823 (fails due to the lack of token only)