### PR TITLE
Fix broken VotingOf storage on testnet

### DIFF
--- a/bin/node/runtime/src/lib.rs
+++ b/bin/node/runtime/src/lib.rs
@@ -1635,7 +1635,6 @@ pub type Executive = frame_executive::Executive<
 // `OnRuntimeUpgrade`.
 type Migrations = (
 	pallet_contracts::Migration<Runtime>,
-	pallet_assets::migration::v1::MigrateToV1<Runtime>,
 );
 
 /// MMR helper types.

--- a/frame/democracy/src/lib.rs
+++ b/frame/democracy/src/lib.rs
@@ -227,7 +227,7 @@ pub mod pallet {
 	use sp_core::H256;
 
 	/// The current storage version.
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(3);
 
 	#[pallet::pallet]
 	#[pallet::generate_store(pub(super) trait Store)]
@@ -563,16 +563,16 @@ pub mod pallet {
 
 		#[cfg(feature = "try-runtime")]
 		fn pre_upgrade() -> Result<Vec<u8>, &'static str> {
-			migrations::v2::Migration::<T>::pre_upgrade()
+			migrations::v3::Migration::<T>::pre_upgrade()
 		}
 
 		fn on_runtime_upgrade() -> Weight {
-			migrations::v2::Migration::<T>::on_runtime_upgrade()
+			migrations::v3::Migration::<T>::on_runtime_upgrade()
 		}
 
 		#[cfg(feature = "try-runtime")]
 		fn post_upgrade(state: Vec<u8>) -> Result<(), &'static str> {
-			migrations::v2::Migration::<T>::post_upgrade(state)
+			migrations::v3::Migration::<T>::post_upgrade(state)
 		}
 	}
 


### PR DESCRIPTION
```
kacper@kacper-HP-ProBook-445-G7 ~/l/liberland_substrate (fix-broken-votings-on-testnet)> git status
On branch fix-broken-votings-on-testnet
Your branch is up to date with 'origin/fix-broken-votings-on-testnet'.

nothing to commit, working tree clean
kacper@kacper-HP-ProBook-445-G7 ~/l/liberland_substrate (fix-broken-votings-on-testnet)> git rev-parse HEAD
c9e91f30a7a97986635cb687b77462e1c9fe1336
kacper@kacper-HP-ProBook-445-G7 ~/l/liberland_substrate (fix-broken-votings-on-testnet)> cargo run --release --features=try-runtime try-runtime on-runtime-upgrade live -u wss://testchain.liberland.org:443
    Finished release [optimized] target(s) in 0.98s
     Running `target/release/substrate try-runtime on-runtime-upgrade live -u 'wss://testchain.liberland.org:443'`
2023-02-01 12:34:26 [0] 💸 generated 1 npos voters, 1 from validators and 0 nominators    
2023-02-01 12:34:26 [0] 💸 generated 1 npos targets    
2023-02-01 12:34:27 Connection established to target: Target { sockaddrs: [], host: "testchain.liberland.org", host_header: "testchain.liberland.org:443", _mode: Tls, path_and_query: "/" }
2023-02-01 12:34:27 scraping key-pairs from remote @ 0x6650e089cd553d6d0d01bcb672a607e9d47bd3b608cfe86fc1065a248a255006    
2023-02-01 12:34:27 downloading data for all pallets.    
2023-02-01 12:34:29 adding data for hashed key: 26aa394eea5630e07c48ae0c9558cef7f9cce9c888469bb1a0dceaa129672ef8    
2023-02-01 12:34:29 extending externalities with 1 manually injected key-values    
2023-02-01 12:34:29 👩‍👦 scraping child-tree data from 0 top keys    
2023-02-01 12:34:29 Custom("[backend]: frontend dropped; terminate client")
2023-02-01 12:34:29 injecting a total of 4824 top keys    
2023-02-01 12:34:29 injecting a total of 0 child keys    
2023-02-01 12:34:29 initialized state externalities with storage root 0x2af2b8037ebf52f696a64f3ab92fed41e3e290e1fb5b0d6a7ffa6c7df44f2f13    
2023-02-01 12:34:31 Connection established to target: Target { sockaddrs: [], host: "testchain.liberland.org", host_header: "testchain.liberland.org:443", _mode: Tls, path_and_query: "/" }
2023-02-01 12:34:31 found matching spec name: "liberland"    
2023-02-01 12:34:31 found matching spec version: 5    
2023-02-01 12:34:31 Custom("[backend]: frontend dropped; terminate client")
2023-02-01 12:34:31 ✅ no migration for System    
2023-02-01 12:34:31 ✅ no migration for Utility    
2023-02-01 12:34:31 ✅ no migration for Babe    
2023-02-01 12:34:31 ✅ no migration for Timestamp    
2023-02-01 12:34:31 ✅ no migration for Authorship    
2023-02-01 12:34:31 ✅ no migration for Indices    
2023-02-01 12:34:31 ✅ no migration for Balances    
2023-02-01 12:34:31 ✅ no migration for TransactionPayment    
2023-02-01 12:34:31 ✅ no migration for AssetTxPayment    
2023-02-01 12:34:31 ✅ no migration for ElectionProviderMultiPhase    
2023-02-01 12:34:31 ✅ no migration for Staking    
2023-02-01 12:34:31 ✅ no migration for Session    
2023-02-01 12:34:31 1 votings will be migrated.    
2023-02-01 12:34:31 ⚠️ Democracy declares internal migrations (which *might* execute). On-chain `StorageVersion(2)` vs current storage version `StorageVersion(3)`    
2023-02-01 12:34:31 migrating votingof    
2023-02-01 12:34:31 1 votings migrated    
2023-02-01 12:34:31 ✅ no migration for Council    
2023-02-01 12:34:31 ✅ no migration for TechnicalCommittee    
2023-02-01 12:34:31 ✅ no migration for TechnicalMembership    
2023-02-01 12:34:31 ✅ no migration for Grandpa    
2023-02-01 12:34:31 ✅ no migration for Treasury    
2023-02-01 12:34:31 ✅ no migration for Contracts    
2023-02-01 12:34:31 ✅ no migration for Sudo    
2023-02-01 12:34:31 ✅ no migration for ImOnline    
2023-02-01 12:34:31 ✅ no migration for AuthorityDiscovery    
2023-02-01 12:34:31 ✅ no migration for Offences    
2023-02-01 12:34:31 ✅ no migration for Historical    
2023-02-01 12:34:31 ✅ no migration for RandomnessCollectiveFlip    
2023-02-01 12:34:31 ✅ no migration for Identity    
2023-02-01 12:34:31 ✅ no migration for Society    
2023-02-01 12:34:31 ✅ no migration for Recovery    
2023-02-01 12:34:31 ✅ no migration for Vesting    
2023-02-01 12:34:31 ✅ no migration for Scheduler    
2023-02-01 12:34:31 ✅ no migration for Preimage    
2023-02-01 12:34:31 ✅ no migration for Proxy    
2023-02-01 12:34:31 ✅ no migration for Multisig    
2023-02-01 12:34:31 ✅ no migration for Bounties    
2023-02-01 12:34:31 ✅ no migration for Tips    
2023-02-01 12:34:31 ✅ no migration for Assets    
2023-02-01 12:34:31 ✅ no migration for Mmr    
2023-02-01 12:34:31 ✅ no migration for Lottery    
2023-02-01 12:34:31 ✅ no migration for Nis    
2023-02-01 12:34:31 ✅ no migration for Uniques    
2023-02-01 12:34:31 ✅ no migration for TransactionStorage    
2023-02-01 12:34:31 ✅ no migration for VoterList    
2023-02-01 12:34:31 ✅ no migration for StateTrieMigration    
2023-02-01 12:34:31 ✅ no migration for ChildBounties    
2023-02-01 12:34:31 ✅ no migration for Referenda    
2023-02-01 12:34:31 ✅ no migration for ConvictionVoting    
2023-02-01 12:34:31 ✅ no migration for Whitelist    
2023-02-01 12:34:31 ✅ no migration for LLM    
2023-02-01 12:34:31 ✅ no migration for LiberlandLegislation    
2023-02-01 12:34:31 ✅ no migration for LiberlandInitializer    
2023-02-01 12:34:31 ✅ no migration for Elections    
2023-02-01 12:34:31 TryRuntime_on_runtime_upgrade executed without errors. Consumed weight = (375000000 ps, 0 byte), total weight = (2000000000000 ps, 18446744073709551615 byte) (0.02 %, 0.00 %).    

```