### PR TITLE
Alternative Dockerfile based on prebuilt binaries

### DIFF
--- a/Dockerfile-prebuilt
+++ b/Dockerfile-prebuilt
@@ -1,0 +1,17 @@
+FROM debian:bullseye-slim as downloader
+ARG VERSION=latest 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl jq && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+RUN curl -sSL https://api.github.com/repos/liberland/liberland_substrate/releases/${VERSION} -o relinfo
+RUN curl -sSL "$(jq -r '.assets[] | select(.name == "linux_x86_build") | .browser_download_url' < relinfo)" -o node
+
+FROM debian:bullseye-slim
+EXPOSE 30333 9933 9944
+VOLUME /data
+RUN useradd -Ms /bin/bash liberland
+COPY --from=downloader /app/node /node
+COPY specs /specs
+RUN mkdir /data && chown liberland:liberland -R /specs /node /data && chmod +x /node
+USER liberland
+ENTRYPOINT [ "/node" ]

--- a/Dockerfile-source
+++ b/Dockerfile-source
@@ -1,8 +1,8 @@
 FROM debian:buster-slim as rusty
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential git clang curl libssl-dev llvm libudev-dev make protobuf-compiler pkg-config && rm -rf /var/lib/apt/lists/*
-RUN curl https://sh.rustup.rs -sSf | CARGO_HOME=/usr/local RUSTUP_HOME=/usr/local sh -s -- --default-toolchain nightly -y
-RUN rustup default nightly
-RUN rustup target add wasm32-unknown-unknown --toolchain nightly
+RUN curl https://sh.rustup.rs -sSf | CARGO_HOME=/usr/local RUSTUP_HOME=/usr/local sh -s -- --default-toolchain nightly-2023-01-01 -y
+RUN rustup default nightly-2023-01-01
+RUN rustup target add wasm32-unknown-unknown --toolchain nightly-2023-01-01
 WORKDIR /app
 
 FROM rusty as builder


### PR DESCRIPTION
I'll want to use it for future releases to make sure docker images have the exact same binary as other methods.