### PR TITLE
 Add `from` field to OutgoingReceipt events 

### DIFF
--- a/eth-bridge/contracts/src/Bridge.sol
+++ b/eth-bridge/contracts/src/Bridge.sol
@@ -60,9 +60,10 @@ error AlreadyVoted();
 /// @title Interface with events emitted by the bridge
 interface BridgeEvents {
     /// Emitted after burn, notifies relays that transfer is happening
-    /// @param amount Amount of token burned
+    /// @param from Account that burned its tokens
     /// @param substrateRecipient Who should get tokens on substrate
-    event OutgoingReceipt(uint256 amount, bytes32 substrateRecipient);
+    /// @param amount Amount of token burned
+    event OutgoingReceipt(address indexed from, bytes32 indexed substrateRecipient, uint256 amount);
 
     /// Bridge get activated or deactivated
     /// @param newBridgeState New bridge state
@@ -76,11 +77,11 @@ interface BridgeEvents {
     /// Vote was cast to approve IncomingReceipt
     /// @param receiptId subject Receipt
     /// @param relay Relay that cast the vote
-    event Vote(bytes32 receiptId, address relay, uint64 substrateBlockNumber);
+    event Vote(bytes32 indexed receiptId, address indexed relay, uint64 substrateBlockNumber);
 
     /// IncomingReceipt was completely processed - tokens were minted
     /// @param receiptId subject Receipt
-    event Processed(bytes32 receiptId);
+    event Processed(bytes32 indexed receiptId);
 
     /// Bridge was emergency stopped by watcher - misbehavior by relay was
     /// detected
@@ -232,14 +233,14 @@ contract Bridge is Initializable, AccessControlUpgradeable, UUPSUpgradeable, Bri
     /// @dev Reverts with `BridgeInactive` if bridge is inactive
     /// @dev Reverts with underlying token's error if bridge is not approved to
     ///      manage funds or if caller has insufficient balance
-    /// @dev Emits `OutgoingReceipt(amount, substrateRecipient)` on success
+    /// @dev Emits `OutgoingReceipt(sender, amount, substrateRecipient)` on success
     /// @dev Interacts with `token` contract
     function burn(uint256 amount, bytes32 substrateRecipient) public {
         // CHECKS
         if (!bridgeActive) revert BridgeInactive();
 
         // EFFECTS
-        emit OutgoingReceipt(amount, substrateRecipient);
+        emit OutgoingReceipt(msg.sender, substrateRecipient, amount);
 
         // INTERACTIONS
         token.burn(msg.sender, amount);

--- a/eth-bridge/contracts/test/Bridge.t.sol
+++ b/eth-bridge/contracts/test/Bridge.t.sol
@@ -75,7 +75,7 @@ contract BridgeTest is Test, BridgeEvents {
 
     function testBurnEmitsReceipt() public {
         vm.expectEmit(false, false, false, false);
-        emit OutgoingReceipt(100, substrate1);
+        emit OutgoingReceipt(address(this), substrate1, 100);
         bridge.burn(100, substrate1);
     }
 

--- a/frame/federated-bridge/src/benchmarking.rs
+++ b/frame/federated-bridge/src/benchmarking.rs
@@ -108,7 +108,7 @@ benchmarks_instance_pallet! {
 	}: _(origin, amount.clone(), eth_recipient.clone())
 	verify {
 		let ev: <T as Config<I>>::RuntimeEvent =
-			Event::<T, I>::OutgoingReceipt { amount, eth_recipient }.into();
+			Event::<T, I>::OutgoingReceipt { from: acc.clone(), amount, eth_recipient }.into();
 		frame_system::Pallet::<T>::assert_last_event(ev.into());
 	}
 

--- a/frame/federated-bridge/src/lib.rs
+++ b/frame/federated-bridge/src/lib.rs
@@ -298,10 +298,12 @@ pub mod pallet {
 	pub enum Event<T: Config<I>, I: 'static = ()> {
 		/// Receipt for substrate -> eth transfer
 		OutgoingReceipt {
-			/// amount transferred
-			amount: BalanceOfToken<T, I>,
+			/// account that deposited funds
+			from: T::AccountId,
 			/// recipient on eth side
 			eth_recipient: EthAddress,
+			/// amount transferred
+			amount: BalanceOfToken<T, I>,
 		},
 		/// Relay voted on approving given eth -> substrate receipt for processing
 		Vote {
@@ -466,7 +468,7 @@ pub mod pallet {
 				amount,
 				Preservation::Expendable,
 			)?;
-			Self::deposit_event(Event::OutgoingReceipt { amount, eth_recipient });
+			Self::deposit_event(Event::OutgoingReceipt { from: who, amount, eth_recipient });
 
 			Ok(())
 		}

--- a/frame/federated-bridge/src/tests.rs
+++ b/frame/federated-bridge/src/tests.rs
@@ -42,7 +42,7 @@ fn deposit_emits_receipt() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(Bridge::deposit(RuntimeOrigin::signed(0), 1, eth_recipient(0)));
 		System::assert_last_event(
-			Event::<Test>::OutgoingReceipt { amount: 1, eth_recipient: eth_recipient(0) }.into(),
+			Event::<Test>::OutgoingReceipt { from: 0, amount: 1, eth_recipient: eth_recipient(0) }.into(),
 		);
 	});
 }


### PR DESCRIPTION
This will make it possible to skip centralized backend in bridge FE.