### PR TITLE
Initial DEX config

### DIFF
--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -1391,7 +1391,7 @@ parameter_types! {
 	pub AllowMultiAssetPools: bool = true;
 	pub const PoolSetupFee: Balance = 1 * DOLLARS; // should be more or equal to the existential deposit
 	pub const MintMinLiquidity: Balance = 100;  // 100 is good enough when the main currency has 10-12 decimals.
-	pub const LiquidityWithdrawalFee: Permill = Permill::from_percent(0);  // should be non-zero if AllowMultiAssetPools is true, otherwise can be zero.
+	pub const LiquidityWithdrawalFee: Permill = Permill::from_parts(0);
 }
 
 impl pallet_asset_conversion::Config for Runtime {
@@ -1400,13 +1400,13 @@ impl pallet_asset_conversion::Config for Runtime {
 	type AssetBalance = <Self as pallet_balances::Config>::Balance;
 	type HigherPrecisionBalance = sp_core::U256;
 	type Assets = Assets;
-	type Balance = u128;
+	type Balance = Balance;
 	type PoolAssets = PoolAssets;
 	type AssetId = <Self as pallet_assets::Config>::AssetId;
 	type MultiAssetId = NativeOrAssetId<u32>;
 	type PoolAssetId = <Self as pallet_assets::Config<Instance2>>::AssetId;
 	type PalletId = AssetConversionPalletId;
-	type LPFee = ConstU32<3>; // means 0.3%
+	type LPFee = ConstU32<5>; // means 0.5%;
 	type PoolSetupFee = PoolSetupFee;
 	type PoolSetupFeeReceiver = AssetConversionOrigin;
 	type LiquidityWithdrawalFee = LiquidityWithdrawalFee;


### PR DESCRIPTION
(note the PR target branch - update if polkadot-v1.1.0 is merged before this one)

Parameters discussed with @DorianSternVukotic.

Hints for FE integration:

# Listing available pairs:

`api.query.assetConversion.pools.entries()`

The key is `[asset1, asset2]`.
Value is `{ lpToken: LP_TOKEN_ID }` and specifies the pool token backing this pool.

# Getting reserves for pool

See https://gist.github.com/kacperzuk-neti/04c130752c8c04df8e8daa8fd1beceda
Useful for calculating results of adding/removing liquidity.

# Create Pool:

`assetConversion.createPool`
  * `Native` is LLD
  * `Asset` are assets from pallet-assets. Asset ID 1 = LLM.
  * creation of pool creates a Liquidity Pool Asset owned by the assetConversion pallet. Note that these assets are in `poolAssets` pallet, not the normal `assets`.

# Add liquidity:
`assetConversion.addLiquidity`
  * initially, when there are no funds in the pool, you can ignore `min` amounts - exactly `desired` amount of both will always be added
  * in exchange for providing the liquidity, user receives poolAsset tokens (freshly minted)
  * if there are already some assets in the pool, the price is respected. So if 1 LLM = 0.1 LLD, and I set both amounts_desired to 100, it will take 100 LLM but only 10 LLD (or fail if it's less than the min amount).
  * assets get stored in account unique to this pool - derivation is non-trivial, use the getReserves runtime call - https://gist.github.com/kacperzuk-neti/04c130752c8c04df8e8daa8fd1beceda

# Trade:

No gotchas here :shrug:

`assetConversion.swapExactTokensForTokens`
`assetConversion.swapTokensForExactTokens`

See https://gist.github.com/kacperzuk-neti/04c130752c8c04df8e8daa8fd1beceda for price info and actual trade result simulations.

# Remove liquidity

assetConversion.removeLiquidity

There are following important variables:
* amount of liquidity pool tokens user wants to burn
* total supply of liquidity pool tokens
* amount of asset reserves in the pool
* LiquidityWithdrawalFee

Assume:
* total supply = 100 lp tokens
* 100 LLM and 10 LLD in the pool
* user calls removeLiquidity, burning 10 lp tokens
* fee 0.1%

The amount of LLM and LLD user will get is equal to:
* 100 LLM * 10 burned lp tokens / 100 total supply lp tokens * (1 - 0.1% fee) = 10 LLM * 99.9% = 9.99 LLM
* 10 LLD * 10 burned lp tokens / 100 total supply lp tokens * (1 - 0.1% fee) = 1 LLD * 99.9% = 0.99 LLD