### PR TITLE
Use HTTPS for liberland-fork-substrate git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "substrate/scripts/fork-test/liberland-fork-substrate"]
 	path = substrate/scripts/fork-test/liberland-fork-substrate
-	url = git@github.com:liberland/liberland-fork-substrate.git
+	url = https://github.com/liberland/liberland-fork-substrate.git
 [submodule "substrate/eth-bridge/contracts/lib/forge-std"]
 	path = substrate/eth-bridge/contracts/lib/forge-std
 	url = https://github.com/foundry-rs/forge-std


### PR DESCRIPTION
Will allow using fork-testing without SSH key linked to GH Account. Use `git submodule sync --recursive` or reclone repo to update.