### PR TITLE
Build & publish docker image as part of release CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,32 @@
+name: Build & publish Docker image
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build-and-publish-docker:
+    permissions: 
+        packages: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+            registry: ghcr.io
+            username: ${{ github.actor }}
+            password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker Image
+        uses: docker/build-push-action@v5
+        with:
+            context: .
+            file: Dockerfile-prebuilt
+            push: true
+            build-args: VERSION=tags/${{ github.ref_name }}
+            tags: ghcr.io/liberland/blockchain-node:${{ github.ref_name }},ghcr.io/liberland/blockchain-node:latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "kitchensink-runtime"
-version = "3.0.0-dev"
+version = "21.0.0"
 dependencies = [
  "bridge-data-signer",
  "bridge-types",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "node-cli"
-version = "3.0.0-dev"
+version = "21.0.0"
 dependencies = [
  "array-bytes",
  "assert_cmd",

--- a/Dockerfile-prebuilt
+++ b/Dockerfile-prebuilt
@@ -7,7 +7,7 @@ RUN curl -sSL https://api.github.com/repos/liberland/liberland_substrate/release
 RUN curl -sSL "$(jq -r '.assets[] | select(.name == "linux_x86_build") | .browser_download_url' < relinfo)" -o node
 
 FROM debian:bullseye-slim
-EXPOSE 30333 9933 9944
+EXPOSE 30333 9944
 VOLUME /data
 RUN useradd -Ms /bin/bash liberland
 COPY --from=downloader /app/node /node

--- a/Dockerfile-source
+++ b/Dockerfile-source
@@ -10,7 +10,7 @@ COPY substrate/ .
 RUN cargo build --release
 
 FROM debian:buster-slim AS runtime
-EXPOSE 30333 9933 9944
+EXPOSE 30333 9944
 VOLUME /data
 COPY --from=builder /app/target/release/substrate /node
 COPY substrate/specs /specs

--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "node-cli"
-version = "3.0.0-dev"
+version = "21.0.0"
 authors.workspace = true
-description = "Generic Substrate node implementation in Rust."
+description = "Liberland node implementation in Rust."
 build = "build.rs"
 edition.workspace = true
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitchensink-runtime"
-version = "3.0.0-dev"
+version = "21.0.0"
 authors.workspace = true
 description = "Substrate node kitchensink runtime."
 edition.workspace = true


### PR DESCRIPTION
I consistently forget to push new docker image to Docker Hub manually. Doesn't matter for runtime-only upgrades, but will matter when we need to change chain-spec or node. With this change, image will be built automatically during release and published on GitHub Container Registry.