### PR TITLE
Add try-runtime test to CI + bump spec_version to 22

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,8 +159,20 @@ jobs:
             target/
           key: ${{ runner.os }}-cargo-rust-${{ hashFiles('**/Cargo.lock') }}
 
-      - name: Check try-runtime build
-        run: cargo build --release --features try-runtime
+      - name: Build try-runtime bastiat runtime
+        run: cargo build --release --features try-runtime,testnet-runtime -p kitchensink-runtime
+      
+      - name: Install try-runtime CLI
+        run: cargo install --git https://github.com/paritytech/try-runtime-cli --locked
+
+      - name: try-runtime bastiat
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://archive.testchain.liberland.org:443
+        
+      - name: Build try-runtime mainnet runtime
+        run: cargo build --release --features try-runtime -p kitchensink-runtime
+
+      - name: try-runtime mainnet
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://mainnet.liberland.org:443
 
   build:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4048,7 +4048,7 @@ dependencies = [
 
 [[package]]
 name = "kitchensink-runtime"
-version = "21.0.0"
+version = "22.0.0"
 dependencies = [
  "bridge-data-signer",
  "bridge-types",
@@ -5339,7 +5339,7 @@ dependencies = [
 
 [[package]]
 name = "node-cli"
-version = "21.0.0"
+version = "22.0.0"
 dependencies = [
  "array-bytes",
  "assert_cmd",

--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-cli"
-version = "21.0.0"
+version = "22.0.0"
 authors.workspace = true
 description = "Liberland node implementation in Rust."
 build = "build.rs"

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "kitchensink-runtime"
-version = "21.0.0"
+version = "22.0.0"
 authors.workspace = true
-description = "Substrate node kitchensink runtime."
+description = "Liberland node runtime."
 edition.workspace = true
 build = "build.rs"
 license = "Apache-2.0"

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -155,7 +155,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 21,
+	spec_version: 22,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -172,7 +172,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 21,
+	spec_version: 22,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/try-runtime-testing.md
+++ b/try-runtime-testing.md
@@ -1,6 +1,14 @@
-1. `cargo install --git https://github.com/paritytech/try-runtime-cli --locked`
-2. `cargo build --features try-runtime --release`
-3. Test mainnet runtime upgrade: `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://mainnet.liberland.org:443`
-4. Run your own local Bastiat node (public one doesn't support HTTPS currently used by `try-runtime`): `./target/release/substrate-node --tmp --chain bastiat`
-5. Wait for node to sync
-6. `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri ws://localhost:9944`
+# Install try-runtime CLI
+```
+cargo install --git https://github.com/paritytech/try-runtime-cli --locked
+```
+
+# Test mainnet
+
+1. Build runtime: `cargo build --features try-runtime --release`
+2. Execute test: `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://mainnet.liberland.org:443`
+
+# Test bastiat
+
+1. Build runtime: `cargo build --features try-runtime,testnet-runtime --release`
+2. Execute test: `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://archive.testchain.liberland.org:443`


### PR DESCRIPTION
Perform try-runtime testing as part of our CI.

try-runtime does basic sanity checks like:
* is old and new runtime for the same chain
* did spec_version increase
* do all pallets versions match the storage versions after upgrade (a.k.a. did we add all migrations to the runtime)

We do this manually for every release already, this will speed up releasing new runtimes and make sure we don't forget this or do it incorrectly.