### PR TITLE
BLOCKCHAIN-439 - Force Congress to use Scheduler for spending funds

### DIFF
--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -417,6 +417,11 @@ type EnsureRootOrHalfSenate = EitherOfDiverse<
 	EnsureSenateMajority,
 >;
 
+type EnsureRootOrHalfSenateOrCustomCouncil = EitherOfDiverse<
+	EnsureRootOrHalfSenate,
+	EnsureSignedBy<CouncilAccount, AccountId>
+>;
+
 parameter_types! {
 	pub MaximumSchedulerWeight: Weight = Perbill::from_percent(80) *
 		RuntimeBlockWeights::get().max_block;
@@ -428,7 +433,7 @@ impl pallet_scheduler::Config for Runtime {
 	type PalletsOrigin = OriginCaller;
 	type RuntimeCall = RuntimeCall;
 	type MaximumWeight = MaximumSchedulerWeight;
-	type ScheduleOrigin = EnsureRootOrHalfSenate;
+	type ScheduleOrigin = EnsureRootOrHalfSenateOrCustomCouncil;
 	#[cfg(feature = "runtime-benchmarks")]
 	type MaxScheduledPerBlock = ConstU32<512>;
 	#[cfg(not(feature = "runtime-benchmarks"))]

--- a/substrate/frame/custom-account/src/lib.rs
+++ b/substrate/frame/custom-account/src/lib.rs
@@ -56,7 +56,7 @@ pub mod pallet {
 	use frame_support::{
 		dispatch::GetDispatchInfo,
 		pallet_prelude::{DispatchResult, *},
-		traits::{Contains, OnUnbalanced, OriginTrait},
+		traits::{Contains, OnUnbalanced, OriginTrait, SortedMembers},
 		PalletId,
 	};
 	use frame_system::{pallet_prelude::*, RawOrigin};
@@ -162,5 +162,13 @@ pub mod pallet {
 			let _ = T::Currency::resolve_creating(&call_account_id, amount);
 			Self::deposit_event(Event::Deposit { value: numeric_amount });
 		}
+	}
+
+	impl<T: Config<I>, I: 'static> SortedMembers<T::AccountId> for Pallet<T, I> {
+		fn sorted_members() -> Vec<T::AccountId> {
+			vec![T::PalletId::get().into_account_truncating()]
+		}
+		#[cfg(feature = "runtime-benchmarks")]
+		fn add(_m: &T::AccountId) {}
 	}
 }

--- a/substrate/frame/custom-account/src/tests.rs
+++ b/substrate/frame/custom-account/src/tests.rs
@@ -10,8 +10,7 @@ THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR I
 #![cfg(test)]
 
 use crate::{mock::*, Event, NegativeImbalanceOf};
-use frame_support::traits::Imbalance;
-use frame_support::traits::OnUnbalanced;
+use frame_support::traits::{Imbalance, OnUnbalanced, SortedMembers};
 use frame_support::{assert_noop, assert_ok, error::BadOrigin};
 use sp_runtime::traits::{AccountIdConversion, Hash};
 
@@ -79,5 +78,15 @@ fn execute_unbalanced() {
 		let balance_after = Balances::free_balance(call_account_id);
 		assert_eq!(balance_before, balance_after - 100);
 		System::assert_last_event(Event::<Test>::Deposit { value: amount }.into());
+	});
+}
+
+#[test]
+fn sorted_members_are_correct() {
+	new_test_ext().execute_with(|| {
+		let call_account_id: u64 = CustomAccountPalletId::get().into_account_truncating();
+		let members = CustomAccount::sorted_members();
+		assert_eq!(members.len(), 1);
+		assert_eq!(members[0], call_account_id)
 	});
 }


### PR DESCRIPTION
This PR:
1. allows Congress-owned CustomAccount to schedule stuff on scheduler
2. forces Congress to use scheduler with at least 4 days delay for calls made via CustomAccount

Important - this in no way affects direct Congress calls (without CustomAccount). So congress will still be able to do the following without going through scheduler:
* Schedule anything as Congress origin (so schedule anything from this very list, but not anything else)
* Act as [Admin for pallet_staking](https://paritytech.github.io/polkadot-sdk/master/pallet_staking/trait.Config.html#associatedtype.AdminOrigin)
* Act as [ForceOrigin for validator elections](https://paritytech.github.io/polkadot-sdk/master/pallet_election_provider_multi_phase/pallet/trait.Config.html#associatedtype.ForceOrigin)
* Do democracy stuff (fast-tracking referenda, proposing referenda with simplified tallying, cancelling referenda etc.)
* Control TechnicalCommittee members

Sample call that works (note that for this test the 4 days required delay was temporarily removed):
![Screenshot from 2024-05-17 14-09-05](https://github.com/liberland/liberland_substrate/assets/117277751/13896b9f-6ba9-4c49-80ff-76f9d90a8567)
![Screenshot from 2024-05-17 14-09-42](https://github.com/liberland/liberland_substrate/assets/117277751/f4228d65-18a6-49d2-b6d0-4aeb94f8dc41)
![Screenshot from 2024-05-17 14-10-52](https://github.com/liberland/liberland_substrate/assets/117277751/910848c5-e711-41e7-af4c-c06cc52c8ea8)