### PR TITLE
Add telemetry to chain specs

### DIFF
--- a/substrate/specs/bastiat.json
+++ b/substrate/specs/bastiat.json
@@ -7,7 +7,12 @@
     "/dns/bootnode-2.testchain.liberland.org/tcp/30333/p2p/12D3KooWNUFT7agTugfRJMbVp22Y5MHpUvnjZU6n6rVH1ovHhGxm",
     "/dns/bootnode-3.testchain.liberland.org/tcp/30333/p2p/12D3KooWBVTvE4yx6WnGCAkBEMxLMDiHbgyh3WKFcBeyhrvJMT3k"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "wss://telemetry.polkadot.io/submit/",
+      1
+    ]
+  ],
   "protocolId": null,
   "properties": {
     "displayName": "Bastiat",

--- a/substrate/specs/bastiat.raw.json
+++ b/substrate/specs/bastiat.raw.json
@@ -7,7 +7,12 @@
     "/dns/bootnode-2.testchain.liberland.org/tcp/30333/p2p/12D3KooWNUFT7agTugfRJMbVp22Y5MHpUvnjZU6n6rVH1ovHhGxm",
     "/dns/bootnode-3.testchain.liberland.org/tcp/30333/p2p/12D3KooWBVTvE4yx6WnGCAkBEMxLMDiHbgyh3WKFcBeyhrvJMT3k"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "wss://telemetry.polkadot.io/submit/",
+      1
+    ]
+  ],
   "protocolId": null,
   "properties": {
     "displayName": "Bastiat",

--- a/substrate/specs/mainnet.json
+++ b/substrate/specs/mainnet.json
@@ -7,7 +7,12 @@
     "/dns/bootnode-2.mainnet.liberland.org/tcp/30333/p2p/12D3KooWLyiY3xdj2vJepd6rwLqJXReH4P5s7qtQKVRGbuWWymxY",
     "/dns/bootnode-3.mainnet.liberland.org/tcp/30333/p2p/12D3KooWFkFW6LwWHf8FwvbbT1D5yukto12GX5z5QUmB5eXXn5Bn"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "wss://telemetry.polkadot.io/submit/",
+      1
+    ]
+  ],
   "protocolId": null,
   "properties": {
     "displayName": "Liberland",

--- a/substrate/specs/mainnet.raw.json
+++ b/substrate/specs/mainnet.raw.json
@@ -7,7 +7,12 @@
     "/dns/bootnode-2.mainnet.liberland.org/tcp/30333/p2p/12D3KooWLyiY3xdj2vJepd6rwLqJXReH4P5s7qtQKVRGbuWWymxY",
     "/dns/bootnode-3.mainnet.liberland.org/tcp/30333/p2p/12D3KooWFkFW6LwWHf8FwvbbT1D5yukto12GX5z5QUmB5eXXn5Bn"
   ],
-  "telemetryEndpoints": null,
+  "telemetryEndpoints": [
+    [
+      "wss://telemetry.polkadot.io/submit/",
+      1
+    ]
+  ],
   "protocolId": null,
   "properties": {
     "displayName": "Liberland",


### PR DESCRIPTION
`1` means to include grandpa authority id for nodes that are validators.