### PR TITLE
Improve automated try-runtime tests

### DIFF
--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -36,11 +36,17 @@ jobs:
       - name: Install try-runtime CLI
         run: cargo install --git https://github.com/paritytech/try-runtime-cli --locked
 
-      - name: try-runtime bastiat
-        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://archive.testchain.liberland.org:443
+      - name: try-runtime on-runtime-upgrade bastiat
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade live --uri wss://archive.testchain.liberland.org:443
+
+      - name: try-runtime fast-forward bastiat
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm fast-forward --n-blocks 5 --blocktime 6000 live --uri wss://archive.testchain.liberland.org:443
         
       - name: Build try-runtime mainnet runtime
         run: cargo build --release --features try-runtime -p kitchensink-runtime
 
-      - name: try-runtime mainnet
-        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://mainnet.liberland.org:443
+      - name: try-runtime on-runtime-upgrade mainnet
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade live --uri wss://mainnet.liberland.org:443
+
+      - name: try-runtime fast-forward mainnet
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm fast-forward --n-blocks 5 --blocktime 6000 live --uri wss://mainnet.liberland.org:443


### PR DESCRIPTION
1. reenable idempotency checks on migrations - it's possible we'll need to disable them when bumping to more recent substrate version, as these idempotency checks are relatively recent, so old runtime upgrades in substrate may not be idempotent yet...
2. reenable weight warnings
3. add follow-check test, which executes a few blocks after the upgrade and runs state checks provided by pallets