### PR TITLE
Pin specific version of try-runtime-cli to fix CI

### DIFF
--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -31,7 +31,7 @@ jobs:
         run: cargo build --release --features try-runtime,testnet-runtime -p kitchensink-runtime
       
       - name: Install try-runtime CLI
-        run: cargo install --git https://github.com/paritytech/try-runtime-cli --locked
+        run: cargo install --git https://github.com/paritytech/try-runtime-cli --locked --tag v0.7.0
 
       - name: try-runtime on-runtime-upgrade bastiat
         run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade live --uri wss://archive.testchain.liberland.org:443


### PR DESCRIPTION
try-runtime-cli v0.8.0 doesn't work with Rust 1.78. But we use Rust 1.78 cause we're on old substrate version that doesn't work with newer Rust.
This PR pins us to an older v0.7.0 version of try-runtime-cli that works fine with rust 1.78.