### PR TITLE
Bump version to 29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4292,7 +4292,7 @@ dependencies = [
 
 [[package]]
 name = "kitchensink-runtime"
-version = "28.0.0"
+version = "29.0.0"
 dependencies = [
  "bridge-data-signer",
  "bridge-types",
@@ -5628,7 +5628,7 @@ dependencies = [
 
 [[package]]
 name = "node-cli"
-version = "28.0.0"
+version = "29.0.0"
 dependencies = [
  "array-bytes",
  "assert_cmd",

--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-cli"
-version = "28.0.0"
+version = "29.0.0"
 authors.workspace = true
 description = "Liberland node implementation in Rust."
 build = "build.rs"

--- a/substrate/bin/node/runtime/Cargo.toml
+++ b/substrate/bin/node/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kitchensink-runtime"
-version = "28.0.0"
+version = "29.0.0"
 authors.workspace = true
 description = "Liberland node runtime."
 edition.workspace = true

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -156,7 +156,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 28,
+	spec_version: 29,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -173,7 +173,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 28,
+	spec_version: 29,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This fixes `try-runtime` GitHub workflow by bumping `node-cli`, `kitchensink-runtime` and `spec_version` to `29`.