### PR TITLE
Hotfix: chainspec ss58format

### DIFF
--- a/substrate/bin/node/cli/Cargo.toml
+++ b/substrate/bin/node/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "node-cli"
-version = "28.0.0"
+version = "28.0.1"
 authors.workspace = true
 description = "Liberland node implementation in Rust."
 build = "build.rs"

--- a/substrate/bin/node/cli/src/chain_spec.rs
+++ b/substrate/bin/node/cli/src/chain_spec.rs
@@ -196,7 +196,7 @@ fn properties() -> sc_chain_spec::Properties {
 	p.insert("tokenSymbol".into(), "LLD".into());
 	p.insert("tokenDecimals".into(), 12.into());
 	p.insert("standardAccount".into(), "*25519".into());
-	p.insert("ss58Format".into(), 56.into());
+	p.insert("ss58Format".into(), 42.into());
 	p.insert("website".into(), "https://liberland.org".into());
 	p
 }


### PR DESCRIPTION
* Fix chainspec `ss58Format` (old value `56`, new value `42`)
* Bump `node-cli` version to `28.0.1`