### PR TITLE
Update ubuntu version used in CI for building node-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     uses: ./.github/workflows/try-runtime.yml
   build_binary:
     # use old ubuntu for GLIBC compatibility
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       RUST_BACKTRACE: 1
     steps:


### PR DESCRIPTION
Use `ubuntu22.04` for building node-cli due to [deprecation](https://github.com/actions/runner-images/issues/11101) of `ubuntu20.04`.