### PR TITLE
Shorten voting period

### DIFF
--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -341,7 +341,7 @@ impl frame_system::Config for Runtime {
 #[cfg(not(feature = "testnet-runtime"))]
 parameter_types! {
 	pub const LaunchPeriod: BlockNumber = 14 * DAYS;
-	pub const VotingPeriod: BlockNumber = 70 * DAYS;
+	pub const VotingPeriod: BlockNumber = 30 * DAYS;
 	pub const TermDuration: BlockNumber = 3 * 30 * DAYS;
 	pub const EnactmentPeriod: BlockNumber = 14 * DAYS;
 	pub const AssetName: &'static str = "Liberland Merit";
@@ -862,7 +862,7 @@ impl pallet_bags_list::Config<VoterBagsListInstance> for Runtime {
 }
 
 parameter_types! {
-	pub const FastTrackVotingPeriod: BlockNumber = 75 * DAYS;
+	pub const FastTrackVotingPeriod: BlockNumber = 14 * DAYS;
 	pub const MinimumDeposit: Balance = 10 * GRAINS_IN_LLM;
 	pub const CooloffPeriod: BlockNumber = 7 * DAYS;
 	pub const MaxProposals: u32 = 100;

--- a/substrate/bin/node/runtime/src/lib.rs
+++ b/substrate/bin/node/runtime/src/lib.rs
@@ -214,7 +214,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 34,
+	spec_version: 35,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,
@@ -231,7 +231,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	// and set impl_version to 0. If only runtime
 	// implementation changes and behavior does not, then leave spec_version as
 	// is and increment impl_version.
-	spec_version: 34,
+	spec_version: 35,
 	impl_version: 0,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,


### PR DESCRIPTION
This shortens voting periods for standard and fast-track proposals.

- Standard voting period is set to 30 days (previously 70 days)
- Fast-track voting period is set to 14 days (previously 75 days)