### PR TITLE
Update deprecated CI action versions

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -19,7 +19,7 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.13.1
         with:
           access_token: ${{ github.token }}
 
@@ -30,7 +30,7 @@ jobs:
         run: rustup component add --toolchain $RUSTUP_TOOLCHAIN rustfmt
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       # this is needed to make sure that cargo uses the cached target files,
       # which will have an older date than the checked out source code.

--- a/.github/workflows/fork-test.yml
+++ b/.github/workflows/fork-test.yml
@@ -13,7 +13,7 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.13.1
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -15,7 +15,7 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.13.1
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.13.1
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -13,7 +13,7 @@ jobs:
       RUST_BACKTRACE: 1
     steps:
       - name: Cancel previous runs
-        uses: styfle/cancel-workflow-action@0.9.1
+        uses: styfle/cancel-workflow-action@0.13.1
         with:
           access_token: ${{ github.token }}
 


### PR DESCRIPTION
## Summary
- update the remaining `actions/checkout@v2` use to v4
- update `styfle/cancel-workflow-action` from 0.9.1 to 0.13.1 across workflows

## Why
The old action releases run on deprecated Node runtimes and generate CI deprecation warnings.

## Verification
- all changed workflow YAML files parsed successfully
- diff is limited to action versions
