### PR TITLE
Run the fork checker without implicit npx installs

### DIFF
--- a/.github/workflows/fork-test.yml
+++ b/.github/workflows/fork-test.yml
@@ -38,7 +38,8 @@ jobs:
         run: |
             ./run-fork.sh mainnet.config.sh &
             cd check-unknowns
-            timeout 5m npx ts-node src/index.ts
+            yarn build
+            timeout 5m node dist/index.js
         working-directory: substrate/scripts/fork-test
 
       - name: Kill mainnet node
@@ -51,7 +52,8 @@ jobs:
         run: |
             ./run-fork.sh bastiat.config.sh &
             cd check-unknowns
-            timeout 5m npx ts-node src/index.ts
+            yarn build
+            timeout 5m node dist/index.js
         working-directory: substrate/scripts/fork-test
 
       - name: Kill bastiat node

--- a/.github/workflows/fork-test.yml
+++ b/.github/workflows/fork-test.yml
@@ -37,24 +37,64 @@ jobs:
       - name: Run check-unknowns test on mainnet fork
         run: |
             ./run-fork.sh mainnet.config.sh &
+            fork_pid=$!
+            trap 'killall -9 substrate-node 2>/dev/null || true' EXIT
             cd check-unknowns
             yarn build
+            for attempt in $(seq 1 90); do
+              response="$(curl --fail --silent \
+                --header 'content-type: application/json' \
+                --data '{"jsonrpc":"2.0","id":1,"method":"chain_getHeader","params":[]}' \
+                http://127.0.0.1:9944 2>/dev/null || true)"
+              if [[ "$response" == *'"result"'* ]]; then
+                echo "Mainnet fork RPC is ready"
+                break
+              fi
+              if ! kill -0 "$fork_pid" 2>/dev/null; then
+                status=1
+                wait "$fork_pid" || status=$?
+                echo "Mainnet fork exited before RPC readiness (status $status)" >&2
+                exit "$status"
+              fi
+              if [ "$attempt" -eq 90 ]; then
+                echo "Mainnet fork RPC did not become ready within 180 seconds" >&2
+                exit 1
+              fi
+              sleep 2
+            done
             timeout 5m node dist/index.js
         working-directory: substrate/scripts/fork-test
-
-      - name: Kill mainnet node
-        run: killall -9 substrate-node
         
       - name: Standard prod build - bastiat
         run: cargo build --release -F testnet-runtime
 
-      - name: Run check-unknowns test on mainnet fork
+      - name: Run check-unknowns test on Bastiat fork
         run: |
             ./run-fork.sh bastiat.config.sh &
+            fork_pid=$!
+            trap 'killall -9 substrate-node 2>/dev/null || true' EXIT
             cd check-unknowns
             yarn build
+            for attempt in $(seq 1 90); do
+              response="$(curl --fail --silent \
+                --header 'content-type: application/json' \
+                --data '{"jsonrpc":"2.0","id":1,"method":"chain_getHeader","params":[]}' \
+                http://127.0.0.1:9944 2>/dev/null || true)"
+              if [[ "$response" == *'"result"'* ]]; then
+                echo "Bastiat fork RPC is ready"
+                break
+              fi
+              if ! kill -0 "$fork_pid" 2>/dev/null; then
+                status=1
+                wait "$fork_pid" || status=$?
+                echo "Bastiat fork exited before RPC readiness (status $status)" >&2
+                exit "$status"
+              fi
+              if [ "$attempt" -eq 90 ]; then
+                echo "Bastiat fork RPC did not become ready within 180 seconds" >&2
+                exit 1
+              fi
+              sleep 2
+            done
             timeout 5m node dist/index.js
         working-directory: substrate/scripts/fork-test
-
-      - name: Kill bastiat node
-        run: killall -9 substrate-node

--- a/substrate/scripts/fork-test/check-unknowns/.gitignore
+++ b/substrate/scripts/fork-test/check-unknowns/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/substrate/scripts/fork-test/check-unknowns/package.json
+++ b/substrate/scripts/fork-test/check-unknowns/package.json
@@ -3,7 +3,7 @@
   "packageManager": "yarn@1.22.19",
   "scripts": {
     "build": "tsc",
-    "start": "ts-node"
+    "start": "yarn build && node dist/index.js"
   },
   "dependencies": {
     "@polkadot/api": "^10.11.2"


### PR DESCRIPTION
## Summary
- compile the fork checker with its already-declared TypeScript compiler
- wait for a successful JSON-RPC health check before starting the checker timeout
- run `node dist/index.js` directly under the five-minute timeout
- detect early fork-process exits and always clean up the node
- ignore generated `dist/` output

## Why
`ts-node` is not declared by `check-unknowns`. The original workflow invoked it through `npx`, causing an implicit install. End-to-end CI then exposed a second race: the checker started about one minute before the fork RPC was ready and never completed `ApiPromise.create()`.

The workflow now separates the maximum 180-second startup window from the five-minute storage-check window.

## Verification
- `yarn install --frozen-lockfile`
- `yarn build`
- full GitHub Actions fork test passed for both mainnet and Bastiat forks:
  https://github.com/VincenzoImp/liberland_substrate/actions/runs/30542024183
