### PR TITLE
Use the working Bastiat endpoint in try-runtime

### DIFF
--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -30,6 +30,51 @@ jobs:
         with:
           cache-all-crates: "true"
 
+      # try-runtime requires a strictly greater spec version by default, which
+      # rejects non-runtime PRs where both versions are equal. We disable that
+      # check below, but still reject an actual version regression here.
+      - name: Reject runtime version regressions
+        run: |
+          python3 - <<'PY'
+          import json
+          import re
+          import urllib.request
+          from pathlib import Path
+
+          source = Path("substrate/bin/node/runtime/src/lib.rs").read_text()
+          versions = dict(re.findall(
+              r'pub const VERSION: RuntimeVersion = RuntimeVersion \{.*?'
+              r'spec_name: create_runtime_str!\("([^"]+)"\).*?'
+              r'spec_version:\s*(\d+)',
+              source,
+              re.S,
+          ))
+          endpoints = {
+              "Liberland_testnet": "https://testchain.liberland.org:443",
+              "Liberland": "https://mainnet.liberland.org:443",
+          }
+
+          for spec_name, endpoint in endpoints.items():
+              request = urllib.request.Request(
+                  endpoint,
+                  data=json.dumps({
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "method": "state_getRuntimeVersion",
+                      "params": [],
+                  }).encode(),
+                  headers={"content-type": "application/json"},
+              )
+              with urllib.request.urlopen(request, timeout=20) as response:
+                  on_chain = json.load(response)["result"]
+
+              local_version = int(versions[spec_name])
+              on_chain_version = int(on_chain["specVersion"])
+              print(f"{spec_name}: local={local_version}, on-chain={on_chain_version}")
+              if local_version < on_chain_version:
+                  raise SystemExit(f"{spec_name} spec version regressed")
+          PY
+
       - name: Build try-runtime bastiat runtime
         run: cargo build --release --features try-runtime,testnet-runtime -p kitchensink-runtime
 
@@ -37,7 +82,7 @@ jobs:
         run: cargo +1.79.0 install --git https://github.com/paritytech/try-runtime-cli --locked --tag v0.7.0
 
       - name: try-runtime on-runtime-upgrade bastiat
-        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade live --uri wss://testchain.liberland.org:443
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-spec-version-check live --uri wss://testchain.liberland.org:443
 
       - name: try-runtime fast-forward bastiat
         run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm fast-forward --n-blocks 5 --blocktime 6000 live --uri wss://testchain.liberland.org:443
@@ -46,7 +91,7 @@ jobs:
         run: cargo build --release --features try-runtime -p kitchensink-runtime
 
       - name: try-runtime on-runtime-upgrade mainnet
-        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade live --uri wss://mainnet.liberland.org:443
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-spec-version-check live --uri wss://mainnet.liberland.org:443
 
       - name: try-runtime fast-forward mainnet
         run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm fast-forward --n-blocks 5 --blocktime 6000 live --uri wss://mainnet.liberland.org:443

--- a/.github/workflows/try-runtime.yml
+++ b/.github/workflows/try-runtime.yml
@@ -37,10 +37,10 @@ jobs:
         run: cargo +1.79.0 install --git https://github.com/paritytech/try-runtime-cli --locked --tag v0.7.0
 
       - name: try-runtime on-runtime-upgrade bastiat
-        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade live --uri wss://archive.testchain.liberland.org:443
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade live --uri wss://testchain.liberland.org:443
 
       - name: try-runtime fast-forward bastiat
-        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm fast-forward --n-blocks 5 --blocktime 6000 live --uri wss://archive.testchain.liberland.org:443
+        run: try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm fast-forward --n-blocks 5 --blocktime 6000 live --uri wss://testchain.liberland.org:443
 
       - name: Build try-runtime mainnet runtime
         run: cargo build --release --features try-runtime -p kitchensink-runtime

--- a/try-runtime-testing.md
+++ b/try-runtime-testing.md
@@ -3,12 +3,17 @@
 cargo install --git https://github.com/paritytech/try-runtime-cli --locked
 ```
 
+The commands below disable try-runtime's strictly-greater spec-version check so
+that the current runtime can be tested by non-runtime changes. This does not
+replace the required `spec_version` bump when runtime behavior changes; CI still
+rejects versions lower than the corresponding on-chain runtime.
+
 # Test mainnet
 
 1. Build runtime: `cargo build --features try-runtime --release`
-2. Execute test: `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://mainnet.liberland.org:443`
+2. Execute test: `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-spec-version-check --disable-idempotency-checks --no-weight-warnings live --uri wss://mainnet.liberland.org:443`
 
 # Test bastiat
 
 1. Build runtime: `cargo build --features try-runtime,testnet-runtime --release`
-2. Execute test: `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://testchain.liberland.org:443`
+2. Execute test: `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-spec-version-check --disable-idempotency-checks --no-weight-warnings live --uri wss://testchain.liberland.org:443`

--- a/try-runtime-testing.md
+++ b/try-runtime-testing.md
@@ -11,4 +11,4 @@ cargo install --git https://github.com/paritytech/try-runtime-cli --locked
 # Test bastiat
 
 1. Build runtime: `cargo build --features try-runtime,testnet-runtime --release`
-2. Execute test: `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://archive.testchain.liberland.org:443`
+2. Execute test: `try-runtime --runtime ./target/release/wbuild/kitchensink-runtime/kitchensink_runtime.wasm on-runtime-upgrade --disable-idempotency-checks --no-weight-warnings live --uri wss://testchain.liberland.org:443`


### PR DESCRIPTION
## Summary
- use the working Bastiat RPC endpoint
- allow try-runtime checks when local and on-chain `spec_version` are equal
- retain an explicit guard that rejects local spec-version regressions
- keep manual try-runtime documentation aligned with CI

## Why
`archive.testchain.liberland.org` returns HTTP 502. After switching to the working endpoint, end-to-end CI downloaded all 13,388 state keys and exposed the next issue: try-runtime-cli rejects equal versions (`34 -> 34`), which breaks every non-runtime PR.

`--disable-spec-version-check` allows migration checks for unchanged versions. A separate preflight still fails if either local runtime version is lower than its on-chain counterpart; migration, try-state, and fast-forward checks remain enabled.

## Verification
Full GitHub Actions workflow passed for Bastiat and mainnet, including:
- runtime-version regression preflight
- on-runtime-upgrade
- five-block fast-forward

https://github.com/VincenzoImp/liberland_substrate/actions/runs/30542024295
